### PR TITLE
feat(convertkit): do not deactivate the add-on if the PHP or Give Core minimum version does not match #3440

### DIFF
--- a/give-convertkit.php
+++ b/give-convertkit.php
@@ -49,7 +49,7 @@ if ( ! class_exists( 'Give_ConvertKit' ) ) {
 		/**
 		 * @since 1.0.3
 		 *
-		 * @var Give_Mollie The reference the singleton instance of this class.
+		 * @var Give_ConvertKit The reference the singleton instance of this class.
 		 */
 		private static $instance;
 
@@ -62,11 +62,14 @@ if ( ! class_exists( 'Give_ConvertKit' ) ) {
 		 */
 		public $notices = array();
 
+		public $id = 'convertkit';
+		public $label = 'ConvertKit';
+
 		/**
 		 * Returns the singleton instance of this class.
 		 *
 		 * @since 1.0.3
-		 * @return Give_Mollie The singleton instance.
+		 * @return Give_ConvertKit The singleton instance.
 		 */
 		public static function get_instance() {
 			if ( null === self::$instance ) {
@@ -78,7 +81,7 @@ if ( ! class_exists( 'Give_ConvertKit' ) ) {
 		}
 
 		/**
-		 * Setup Give Mollie.
+		 * Setup Give ConvertKit.
 		 *
 		 * @since 1.0.3
 		 * @access private
@@ -106,7 +109,7 @@ if ( ! class_exists( 'Give_ConvertKit' ) ) {
 
 			include( GIVE_CONVERTKIT_PATH . '/includes/class-give-convertkit.php' );
 
-			new Give_ConvertKit_Settings( 'convertkit', 'ConvertKit' );
+			new Give_ConvertKit_Settings( $this->id, $this->label );
 
 			$this->licensing();
 			$this->textdomain();
@@ -300,7 +303,7 @@ if ( ! class_exists( 'Give_ConvertKit' ) ) {
 		}
 
 		/**
-		 * Implement Give Licensing for Give Mollie Add On.
+		 * Implement Give Licensing for Give ConvertKit Add On.
 		 *
 		 * @since 1.0.3
 		 * @access private
@@ -354,7 +357,7 @@ if ( ! class_exists( 'Give_ConvertKit' ) ) {
 	 *
 	 * @since 1.0.3
 	 *
-	 * @return Give_Authorize bool|object
+	 * @return Give_ConvertKit bool|object
 	 */
 	function Give_ConvertKit() {
 		return Give_ConvertKit::get_instance();

--- a/give-convertkit.php
+++ b/give-convertkit.php
@@ -62,7 +62,22 @@ if ( ! class_exists( 'Give_ConvertKit' ) ) {
 		 */
 		public $notices = array();
 
+		/**
+		 * $id (string)
+		 *
+		 * @since 1.0.3
+		 *
+		 * @var array
+		 */
 		public $id = 'convertkit';
+
+		/**
+		 * $label (string)
+		 *
+		 * @since 1.0.3
+		 *
+		 * @var array
+		 */
 		public $label = 'ConvertKit';
 
 		/**

--- a/give-convertkit.php
+++ b/give-convertkit.php
@@ -38,35 +38,327 @@ if ( ! defined( 'GIVE_CONVERTKIT_BASENAME' ) ) {
 	define( 'GIVE_CONVERTKIT_BASENAME', plugin_basename( GIVE_CONVERTKIT_FILE ) );
 }
 
-/**
- * Give - ConvertKit Add-on licensing.
- */
-function give_add_convertkit_licensing() {
+if ( ! class_exists( 'Give_ConvertKit' ) ) {
 
-	if ( class_exists( 'Give_License' ) ) {
-		new Give_License( GIVE_CONVERTKIT_FILE, 'ConvertKit', GIVE_CONVERTKIT_VERSION, 'WordImpress' );
+	/**
+	 * Class Give_ConvertKit
+	 *
+	 * @since 1.0.3
+	 */
+	class Give_ConvertKit {
+		/**
+		 * @since 1.0.3
+		 *
+		 * @var Give_Mollie The reference the singleton instance of this class.
+		 */
+		private static $instance;
+
+		/**
+		 * Notices (array)
+		 *
+		 * @since 1.0.3
+		 *
+		 * @var array
+		 */
+		public $notices = array();
+
+		/**
+		 * Returns the singleton instance of this class.
+		 *
+		 * @since 1.0.3
+		 * @return Give_Mollie The singleton instance.
+		 */
+		public static function get_instance() {
+			if ( null === self::$instance ) {
+				self::$instance = new self();
+				self::$instance->setup();
+			}
+
+			return self::$instance;
+		}
+
+		/**
+		 * Setup Give Mollie.
+		 *
+		 * @since 1.0.3
+		 * @access private
+		 */
+		public function setup() {
+
+			// Give init hook.
+			add_action( 'give_init', array( $this, 'init' ), 10 );
+			add_action( 'admin_init', array( $this, 'check_environment' ), 999 );
+			add_action( 'admin_notices', array( $this, 'admin_notices' ), 15 );
+		}
+
+		/**
+		 * Init the plugin after plugins_loaded so environment variables are set.
+		 *
+		 * @since 1.0.3
+		 */
+		public function init() {
+			if ( ! $this->get_environment_warning() ) {
+				return;
+			}
+
+			include( GIVE_CONVERTKIT_PATH . '/includes/give-convertkit-activation.php' );
+
+
+			include( GIVE_CONVERTKIT_PATH . '/includes/class-give-convertkit.php' );
+
+			new Give_ConvertKit_Settings( 'convertkit', 'ConvertKit' );
+
+			$this->licensing();
+			$this->textdomain();
+			$this->give_convertkit_activation_banner();
+
+			// Scripts.
+			add_action( 'admin_enqueue_scripts', array( $this, 'admin_scripts' ), 100 );
+		}
+
+		/**
+		 * Check plugin environment.
+		 *
+		 * @since 1.0.3
+		 * @access public
+		 *
+		 * @return bool
+		 */
+		public function check_environment() {
+			// Flag to check whether plugin file is loaded or not.
+			$is_working = true;
+
+			// Load plugin helper functions.
+			if ( ! function_exists( 'is_plugin_active' ) ) {
+				require_once ABSPATH . '/wp-admin/includes/plugin.php';
+			}
+
+			/* Check to see if Give is activated, if it isn't deactivate and show a banner. */
+			// Check for if give plugin activate or not.
+			$is_give_active = defined( 'GIVE_PLUGIN_BASENAME' ) ? is_plugin_active( GIVE_PLUGIN_BASENAME ) : false;
+
+			if ( empty( $is_give_active ) ) {
+				// Show admin notice.
+				$this->add_admin_notice( 'prompt_give_activate', 'error', sprintf( __( '<strong>Activation Error:</strong> You must have the <a href="%s" target="_blank">Give</a> plugin installed and activated for Give - ConvertKit to activate.', 'give-convertkit' ), 'https://givewp.com' ) );
+				$is_working = false;
+			}
+
+			return $is_working;
+		}
+
+		/**
+		 * Check plugin for Give environment.
+		 *
+		 * @since 1.0.3
+		 * @access public
+		 *
+		 * @return bool
+		 */
+		public function get_environment_warning() {
+			// Flag to check whether plugin file is loaded or not.
+			$is_working = true;
+
+			// Verify dependency cases.
+			if (
+				defined( 'GIVE_VERSION' )
+				&& version_compare( GIVE_VERSION, GIVE_CONVERTKIT_MIN_GIVE_VERSION, '<' )
+			) {
+
+				/* Min. Give. plugin version. */
+				// Show admin notice.
+				$this->add_admin_notice( 'prompt_give_incompatible', 'error', sprintf( __( '<strong>Activation Error:</strong> You must have the <a href="%s" target="_blank">Give</a> core version %s for the Give - ConvertKit add-on to activate.', 'give-convertkit' ), 'https://givewp.com', GIVE_CONVERTKIT_MIN_GIVE_VERSION ) );
+
+				$is_working = false;
+			}
+
+			return $is_working;
+		}
+
+
+		/**
+		 * Load the plugin's textdomain
+		 *
+		 * @since 1.0.3
+		 */
+		public function textdomain() {
+
+			// Set filter for language directory.
+			$lang_dir = GIVE_CONVERTKIT_DIR . '/languages/';
+			$lang_dir = apply_filters( 'give_convertkit_languages_directory', $lang_dir );
+
+			// Traditional WordPress plugin locale filter.
+			$locale = apply_filters( 'plugin_locale', get_locale(), 'give-convertkit' );
+			$mofile = sprintf( '%1$s-%2$s.mo', 'give-convertkit', $locale );
+
+			// Setup paths to current locale file.
+			$mofile_local  = $lang_dir . $mofile;
+			$mofile_global = WP_LANG_DIR . '/give-convertkit/' . $mofile;
+
+			if ( file_exists( $mofile_global ) ) {
+				// Look in global /wp-content/languages/give-convertkit/ folder.
+				load_textdomain( 'give-convertkit', $mofile_global );
+			} elseif ( file_exists( $mofile_local ) ) {
+				// Look in local /wp-content/plugins/give-convertkit/languages/ folder.
+				load_textdomain( 'give-convertkit', $mofile_local );
+			} else {
+				// Load the default language files.
+				load_plugin_textdomain( 'give-convertkit', false, $lang_dir );
+			}
+
+		}
+
+		/**
+		 * Load Admin Scripts
+		 *
+		 * Enqueues the required admin scripts.
+		 *
+		 * @since 1.0.3
+		 * @global       $post
+		 *
+		 * @param string $hook Page hook
+		 *
+		 * @return void
+		 */
+		public function admin_scripts( $hook ) {
+
+			global $post_type;
+
+			// Directories of assets.
+			$js_dir  = GIVE_CONVERTKIT_URL . 'assets/js/';
+			$css_dir = GIVE_CONVERTKIT_URL . 'assets/css/';
+
+			wp_register_script( 'give_' . $this->id . '_admin_ajax_js', $js_dir . 'admin-ajax.js', array( 'jquery' ) );
+			wp_register_style( 'give_' . $this->id . '_admin_css', $css_dir . 'admin-forms.css', GIVE_CONVERTKIT_VERSION );
+			wp_register_script( 'give_' . $this->id . '_admin_forms_scripts', $js_dir . 'admin-forms.js', array( 'jquery' ), GIVE_CONVERTKIT_VERSION, false );
+
+			// Forms CPT Script.
+			if ( $post_type === 'give_forms' ) {
+
+				// CSS.
+				wp_enqueue_style( 'give_' . $this->id . '_admin_css' );
+
+				// JS.
+				wp_enqueue_script( 'give_' . $this->id . '_admin_forms_scripts' );
+				wp_enqueue_script( 'give_' . $this->id . '_admin_ajax_js' );
+			}
+
+			// Admin settings.
+			if ( $hook == 'give_forms_page_give-settings' ) {
+
+				// JS/CSS.
+				wp_enqueue_script( 'give_' . $this->id . '_admin_ajax_js' );
+				wp_enqueue_style( 'give_' . $this->id . '_admin_css' );
+
+			}
+
+		}
+
+		/**
+		 * Allow this class and other classes to add notices.
+		 *
+		 * @since 1.0.3
+		 *
+		 * @param $slug
+		 * @param $class
+		 * @param $message
+		 */
+		public function add_admin_notice( $slug, $class, $message ) {
+			$this->notices[ $slug ] = array(
+				'class'   => $class,
+				'message' => $message,
+			);
+		}
+
+		/**
+		 * Display admin notices.
+		 *
+		 * @since 1.0.3
+		 */
+		public function admin_notices() {
+
+			$allowed_tags = array(
+				'a'      => array(
+					'href'  => array(),
+					'title' => array(),
+					'class' => array(),
+					'id'    => array(),
+				),
+				'br'     => array(),
+				'em'     => array(),
+				'span'   => array(
+					'class' => array(),
+				),
+				'strong' => array(),
+			);
+
+			foreach ( (array) $this->notices as $notice_key => $notice ) {
+				echo "<div class='" . esc_attr( $notice['class'] ) . "'><p>";
+				echo wp_kses( $notice['message'], $allowed_tags );
+				echo '</p></div>';
+			}
+
+		}
+
+		/**
+		 * Implement Give Licensing for Give Mollie Add On.
+		 *
+		 * @since 1.0.3
+		 * @access private
+		 */
+		public function licensing() {
+			if ( class_exists( 'Give_License' ) ) {
+				new Give_License( GIVE_CONVERTKIT_FILE, 'ConvertKit', GIVE_CONVERTKIT_VERSION, 'WordImpress' );
+			}
+		}
+
+		/**
+		 * Show activation banner for this add-on.
+		 *
+		 * @since 1.0.3
+		 *
+		 * @return bool
+		 */
+		public function give_convertkit_activation_banner() {
+
+			// Check for activation banner inclusion.
+			if (
+				! class_exists( 'Give_Addon_Activation_Banner' )
+				&& file_exists( GIVE_PLUGIN_DIR . 'includes/admin/class-addon-activation-banner.php' )
+			) {
+				include GIVE_PLUGIN_DIR . 'includes/admin/class-addon-activation-banner.php';
+			}
+
+			// Initialize activation welcome banner.
+			if ( class_exists( 'Give_Addon_Activation_Banner' ) ) {
+
+				//Only runs on admin
+				$args = array(
+					'file'              => __FILE__,
+					'name'              => esc_html__( 'ConvertKit', 'give-convertkit' ),
+					'version'           => GIVE_CONVERTKIT_VERSION,
+					'settings_url'      => admin_url( 'edit.php?post_type=give_forms&page=give-settings&tab=addons&section=convertkit-settings' ),
+					'documentation_url' => 'http://docs.givewp.com/addon-convertkit',
+					'support_url'       => 'https://givewp.com/support/',
+					'testing'           => false
+				);
+
+				new Give_Addon_Activation_Banner( $args );
+			}
+
+			return true;
+		}
 	}
 
-}
-
-add_action( 'plugins_loaded', 'give_add_convertkit_licensing' );
-
-
-/**
- * Give ConvertKit Includes.
- */
-function give_convertkit_includes() {
-
-	include( GIVE_CONVERTKIT_PATH . '/includes/give-convertkit-activation.php' );
-
-	if ( ! class_exists( 'Give' ) ) {
-		return false;
+	/**
+	 * Returns class object instance.
+	 *
+	 * @since 1.0.3
+	 *
+	 * @return Give_Authorize bool|object
+	 */
+	function Give_ConvertKit() {
+		return Give_ConvertKit::get_instance();
 	}
 
-	include( GIVE_CONVERTKIT_PATH . '/includes/class-give-convertkit.php' );
-
-	new Give_ConvertKit( 'convertkit', 'ConvertKit' );
-
+	Give_ConvertKit();
 }
-
-add_action( 'plugins_loaded', 'give_convertkit_includes' );

--- a/includes/class-give-convertkit.php
+++ b/includes/class-give-convertkit.php
@@ -3,9 +3,9 @@
 /**
  * Class Give_ConvertKit
  *
- * @since       1.0
+ * @since 1.0.3
  */
-class Give_ConvertKit {
+class Give_ConvertKit_Settings {
 
 	/**
 	 * The ID for this newsletter Add-on, such as 'convertkit'
@@ -49,16 +49,12 @@ class Give_ConvertKit {
 		$this->give_options = give_get_settings();
 		$this->api_key      = trim( give_get_option( 'give_convertkit_api', '' ) );
 
-		add_action( 'init', array( $this, 'textdomain' ) );
 		add_action( 'add_meta_boxes', array( $this, 'add_metabox' ) );
 		add_action( 'save_post', array( $this, 'save_metabox' ) );
 
 		add_filter( 'give_settings_addons', array( $this, 'settings' ) );
 		add_action( 'give_donation_form_before_submit', array( $this, 'form_fields' ), 100, 1 );
 		add_action( 'give_insert_payment', array( $this, 'completed_donation_signup' ), 10, 2 );
-
-		// Scripts.
-		add_action( 'admin_enqueue_scripts', array( $this, 'admin_scripts' ), 100 );
 
 		// Donation metabox.
 		add_filter( 'give_view_donation_details_totals_after', array( $this, 'donation_metabox_notification' ), 10, 1 );
@@ -89,82 +85,6 @@ class Give_ConvertKit {
 			$this->checkbox_label = trim( $this->give_options['give_convertkit_label'] );
 		} else {
 			$this->checkbox_label = __( 'Signup for the newsletter', 'give-convertkit' );
-		}
-
-	}
-
-	/**
-	 * Load Admin Scripts
-	 *
-	 * Enqueues the required admin scripts.
-	 *
-	 * @since 1.0
-	 * @global       $post
-	 *
-	 * @param string $hook Page hook
-	 *
-	 * @return void
-	 */
-	public function admin_scripts( $hook ) {
-
-		global $post_type;
-
-		// Directories of assets.
-		$js_dir  = GIVE_CONVERTKIT_URL . 'assets/js/';
-		$css_dir = GIVE_CONVERTKIT_URL . 'assets/css/';
-
-		wp_register_script( 'give_' . $this->id . '_admin_ajax_js', $js_dir . 'admin-ajax.js', array( 'jquery' ) );
-		wp_register_style( 'give_' . $this->id . '_admin_css', $css_dir . 'admin-forms.css', GIVE_CONVERTKIT_VERSION );
-		wp_register_script( 'give_' . $this->id . '_admin_forms_scripts', $js_dir . 'admin-forms.js', array( 'jquery' ), GIVE_CONVERTKIT_VERSION, false );
-
-		// Forms CPT Script.
-		if ( $post_type === 'give_forms' ) {
-
-			// CSS.
-			wp_enqueue_style( 'give_' . $this->id . '_admin_css' );
-
-			// JS.
-			wp_enqueue_script( 'give_' . $this->id . '_admin_forms_scripts' );
-			wp_enqueue_script( 'give_' . $this->id . '_admin_ajax_js' );
-		}
-
-		// Admin settings.
-		if ( $hook == 'give_forms_page_give-settings' ) {
-
-			// JS/CSS.
-			wp_enqueue_script( 'give_' . $this->id . '_admin_ajax_js' );
-			wp_enqueue_style( 'give_' . $this->id . '_admin_css' );
-
-		}
-
-	}
-
-	/**
-	 * Load the plugin's textdomain
-	 */
-	public function textdomain() {
-
-		// Set filter for language directory.
-		$lang_dir = GIVE_CONVERTKIT_DIR . '/languages/';
-		$lang_dir = apply_filters( 'give_convertkit_languages_directory', $lang_dir );
-
-		// Traditional WordPress plugin locale filter.
-		$locale = apply_filters( 'plugin_locale', get_locale(), 'give-convertkit' );
-		$mofile = sprintf( '%1$s-%2$s.mo', 'give-convertkit', $locale );
-
-		// Setup paths to current locale file.
-		$mofile_local  = $lang_dir . $mofile;
-		$mofile_global = WP_LANG_DIR . '/give-convertkit/' . $mofile;
-
-		if ( file_exists( $mofile_global ) ) {
-			// Look in global /wp-content/languages/give-convertkit/ folder.
-			load_textdomain( 'give-convertkit', $mofile_global );
-		} elseif ( file_exists( $mofile_local ) ) {
-			// Look in local /wp-content/plugins/give-convertkit/languages/ folder.
-			load_textdomain( 'give-convertkit', $mofile_local );
-		} else {
-			// Load the default language files.
-			load_plugin_textdomain( 'give-convertkit', false, $lang_dir );
 		}
 
 	}
@@ -283,7 +203,7 @@ class Give_ConvertKit {
 	/**
 	 * Subscribe an email to a list.
 	 *
-	 * @param array       $user_info
+	 * @param array $user_info
 	 * @param bool|string $list_id
 	 * @param bool|string $tag_id
 	 *
@@ -401,8 +321,7 @@ class Give_ConvertKit {
 		$list_value = ! empty( $list_value ) ? $list_value : give_get_option( "give_{$this->id}_list" );
 
 		// Global label
-		$global_label = isset( $this->give_options[ 'give_' . $this->id . '_label' ] ) ? $this->give_options[ 'give_' . $this->id . '_label' ] : __( 'Signup for the newsletter', 'give-convertkit' );
-		;
+		$global_label = isset( $this->give_options[ 'give_' . $this->id . '_label' ] ) ? $this->give_options[ 'give_' . $this->id . '_label' ] : __( 'Signup for the newsletter', 'give-convertkit' );;
 
 		// Globally enabled option.
 		$globally_enabled = give_get_option( 'give_' . $this->id . '_show_subscribe_checkbox' );
@@ -593,8 +512,8 @@ class Give_ConvertKit {
 
 		// OK, its safe for us to save the data now.
 		// Sanitize the user input.
-		$give_custom_label      = isset( $_POST[ '_give_' . $this->id . '_custom_label' ] ) ? sanitize_text_field( $_POST[ '_give_' . $this->id . '_custom_label' ] ) : '';
-		$give_custom_lists      = isset( $_POST[ '_give_' . $this->id ] ) ? $_POST[ '_give_' . $this->id ] : give_get_option( "give_{$this->id}_list" );
+		$give_custom_label = isset( $_POST[ '_give_' . $this->id . '_custom_label' ] ) ? sanitize_text_field( $_POST[ '_give_' . $this->id . '_custom_label' ] ) : '';
+		$give_custom_lists = isset( $_POST[ '_give_' . $this->id ] ) ? $_POST[ '_give_' . $this->id ] : give_get_option( "give_{$this->id}_list" );
 
 		$global_tags = isset( $this->give_options[ 'give_' . $this->id . '_tags' ] ) ? $this->give_options[ 'give_' . $this->id . '_tags' ] : '';
 

--- a/includes/give-convertkit-activation.php
+++ b/includes/give-convertkit-activation.php
@@ -14,100 +14,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Give ConvertKit Activation Banner
- *
- * Includes and initializes Give activation banner class.
- *
- * @since 1.0
- */
-function give_convertkit_activation_banner() {
-
-	// Check for if give plugin activate or not.
-	$is_give_active = defined( 'GIVE_PLUGIN_BASENAME' ) ? is_plugin_active( GIVE_PLUGIN_BASENAME ) : false;
-
-	//Check to see if Give is activated, if it isn't deactivate and show a banner
-	if ( current_user_can( 'activate_plugins' ) && ! $is_give_active ) {
-
-		add_action( 'admin_notices', 'give_convertkit_activation_notice' );
-
-		//Don't let this plugin activate
-		deactivate_plugins( GIVE_CONVERTKIT_BASENAME );
-
-		if ( isset( $_GET['activate'] ) ) {
-			unset( $_GET['activate'] );
-		}
-
-		return false;
-
-	}
-
-	//Check minimum Give version
-	if ( defined( 'GIVE_VERSION' ) && version_compare( GIVE_VERSION, GIVE_CONVERTKIT_MIN_GIVE_VERSION, '<' ) ) {
-
-		add_action( 'admin_notices', 'give_convertkit_min_version_notice' );
-
-		//Don't let this plugin activate
-		deactivate_plugins( GIVE_CONVERTKIT_BASENAME );
-
-		if ( isset( $_GET['activate'] ) ) {
-			unset( $_GET['activate'] );
-		}
-
-		return false;
-
-	}
-
-	// Check for activation banner inclusion.
-	if ( ! class_exists( 'Give_Addon_Activation_Banner' )
-	     && file_exists( GIVE_PLUGIN_DIR . 'includes/admin/class-addon-activation-banner.php' )
-	) {
-
-		include GIVE_PLUGIN_DIR . 'includes/admin/class-addon-activation-banner.php';
-	}
-
-	// Initialize activation welcome banner.
-	if ( class_exists( 'Give_Addon_Activation_Banner' ) ) {
-
-		//Only runs on admin
-		$args = array(
-			'file'              => __FILE__,
-			'name'              => esc_html__( 'ConvertKit', 'give-convertkit' ),
-			'version'           => GIVE_CONVERTKIT_VERSION,
-			'settings_url'      => admin_url( 'edit.php?post_type=give_forms&page=give-settings&tab=addons&section=convertkit-settings' ),
-			'documentation_url' => 'http://docs.givewp.com/addon-convertkit',
-			'support_url'       => 'https://givewp.com/support/',
-			'testing'           => false
-		);
-
-		new Give_Addon_Activation_Banner( $args );
-	}
-
-	return false;
-
-}
-
-add_action( 'admin_init', 'give_convertkit_activation_banner' );
-
-/**
- * Notice for No Core Activation
- *
- * @since 1.0
- */
-function give_convertkit_activation_notice() {
-	echo '<div class="error"><p>' . __( '<strong>Activation Error:</strong> You must have the <a href="https://givewp.com/" target="_blank">Give</a> plugin installed and activated for the ConvertKit add-on to activate.', 'give-convertkit' ) . '</p></div>';
-}
-
-/**
- * Notice for No Core Activation
- *
- * @since 1.0
- */
-function give_convertkit_min_version_notice() {
-	echo '<div class="error"><p>' . sprintf( __( '<strong>Activation Error:</strong> You must have <a href="%s" target="_blank">Give</a> version %s+ for the ConvertKit add-on to activate.', 'give-convertkit' ), 'https://givewp.com', GIVE_CONVERTKIT_MIN_GIVE_VERSION ) . '</p></div>';
-}
-
-
-/**
  * Plugins row action links.
  *
  * @since 1.0
@@ -136,7 +42,7 @@ add_filter( 'plugin_action_links_' . GIVE_CONVERTKIT_BASENAME, 'give_convertkit_
  *
  * @since 1.0
  *
- * @param array  $plugin_meta An array of the plugin's metadata.
+ * @param array $plugin_meta An array of the plugin's metadata.
  * @param string $plugin_file Path to the plugin file, relative to the plugins directory.
  *
  * @return array


### PR DESCRIPTION
## Description
PR to fix issue https://github.com/WordImpress/Give/issues/3440 in https://github.com/WordImpress/Give-ConvertKit/

## How Has This Been Tested?
Tested by activating the Add-on when Give Plugin is not activate 
Tested by activating the Add-on when Give Plugin is activated and version is less then what is required 
Tested by activating the Add-on when Give Plugin is activated and updated to the latest version 

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.